### PR TITLE
Personal Access Tokens

### DIFF
--- a/cmd/enseada-server/boot.go
+++ b/cmd/enseada-server/boot.go
@@ -8,7 +8,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"strings"
 
 	"cloud.google.com/go/errorreporting"
@@ -46,8 +48,11 @@ func modules(ctx context.Context, logger log.Logger, conf *viper.Viper, errh err
 		return nil, errors.New("no public host configured")
 	}
 
+	sec := fmt.Sprintf("%x", sha256.Sum256(skb))
+
 	oc := &goauth.Config{
-		ClientID: "enseada",
+		ClientID:     "enseada",
+		ClientSecret: sec,
 		Endpoint: goauth.Endpoint{
 			AuthURL:   ph + "/oauth/authorize",
 			TokenURL:  ph + "/oauth/token",
@@ -89,7 +94,7 @@ func modules(ctx context.Context, logger log.Logger, conf *viper.Viper, errh err
 		return nil, err
 	}
 
-	am, err := auth.NewModule(ctx, logger.Child("auth"), dm.Data, hm.Echo, errh, om.Registry, skb, ph, conf.GetString("root.password"))
+	am, err := auth.NewModule(ctx, logger.Child("auth"), dm.Data, hm.Echo, errh, om.Registry, skb, ph, conf.GetString("root.password"), sec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/flow_personal_access_token.go
+++ b/internal/auth/flow_personal_access_token.go
@@ -1,0 +1,106 @@
+// Copyright 2019-2020 Enseada authors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/compose"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/pkg/errors"
+)
+
+func PersonalAccessTokenFactory(config *compose.Config, storage interface{}, strategy interface{}) interface{} {
+	return &PersonalAccessTokenHandler{
+		HandleHelper: &oauth2.HandleHelper{
+			AccessTokenStrategy:  strategy.(oauth2.AccessTokenStrategy),
+			AccessTokenStorage:   storage.(oauth2.AccessTokenStorage),
+			AccessTokenLifespan:  3153600000 * time.Second, // 100 years
+			RefreshTokenLifespan: -1,
+		},
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+	}
+}
+
+// PersonalAccessTokenHandler is a fosite.Handler that implements
+// the custom personal_access_token grant type for long-lived authorization tokens used by machine accounts
+type PersonalAccessTokenHandler struct {
+	*oauth2.HandleHelper
+	ScopeStrategy            fosite.ScopeStrategy
+	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+}
+
+func (m *PersonalAccessTokenHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
+	// grant_type REQUIRED.
+	// Value MUST be set to "personal_access_token".
+	if !request.GetGrantTypes().Exact("personal_access_token") {
+		return errors.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	if !request.GetClient().GetGrantTypes().Has("personal_access_token") {
+		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The client is not allowed to use authorization grant \"personal_access_token\"."))
+	}
+
+	tkn := request.GetRequestForm().Get("access_token")
+	sig := m.AccessTokenStrategy.AccessTokenSignature(tkn)
+	or, err := m.AccessTokenStorage.GetAccessTokenSession(ctx, sig, request.GetSession())
+	if errors.Cause(err) == fosite.ErrNotFound {
+		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(err.Error()))
+	} else if err != nil {
+		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+	} else if err := m.AccessTokenStrategy.ValidateAccessToken(ctx, or, tkn); err != nil {
+		// The authorization server MUST ... validate the access token.
+		// This needs to happen after store retrieval for the session to be hydrated properly
+		rfce := fosite.ErrorToRFC6749Error(err)
+		if rfce.Name == "error" {
+			return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(err.Error()))
+		} else {
+			return rfce
+		}
+	}
+
+	if or.GetClient().GetID() != request.GetClient().GetID() {
+		return errors.WithStack(fosite.ErrInvalidRequest.WithHint("The OAuth 2.0 Client ID from this request does not match the ID during the initial token issuance."))
+	}
+
+	request.SetSession(or.GetSession().Clone())
+
+	for _, scope := range request.GetGrantedScopes() {
+		if !m.ScopeStrategy(request.GetClient().GetScopes(), scope) {
+			return errors.WithStack(fosite.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request scope \"%s\".", scope))
+		}
+		request.GrantScope(scope)
+	}
+
+	if err := m.AudienceMatchingStrategy(request.GetClient().GetAudience(), or.GetGrantedAudience()); err != nil {
+		return err
+	}
+
+	for _, audience := range request.GetGrantedAudience() {
+		request.GrantAudience(audience)
+	}
+
+	// Personal Access Tokens never expire and don't need to be refreshed.
+	// Since fosite does not allow non-expiring access tokens we set expiration to 100 years.
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(m.AccessTokenLifespan).Round(time.Second))
+	return nil
+}
+
+func (m *PersonalAccessTokenHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
+	if !requester.GetGrantTypes().Exact("personal_access_token") {
+		return errors.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	if err := m.IssueAccessToken(ctx, requester, responder); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/auth/oauth_client_store.go
+++ b/internal/auth/oauth_client_store.go
@@ -112,15 +112,14 @@ func (c *OAuthClientStore) SaveClient(ctx context.Context, client fosite.Client)
 	return nil
 }
 
-func (c *OAuthClientStore) InitDefaultClients(ctx context.Context, ph string) error {
+func (c *OAuthClientStore) InitDefaultClients(ctx context.Context, ph string, sec string) error {
 	db := c.Data.DB(ctx, couch.OAuthDB)
 
-	client, err := NewOAuthClient("enseada", "",
-		OAuthGrantTypes("authorization_code", "implicit", "refresh_token", "password", "client_credentials"),
+	client, err := NewOAuthClient("enseada", sec,
+		OAuthGrantTypes("authorization_code", "implicit", "refresh_token", "password", "client_credentials", "personal_access_token"),
 		OAuthResponseTypes("code", "id_token", "token id_token", "code id_token", "code token", "code token id_token"),
 		OAuthScopes("*"),
 		OAuthRedirectURIs(ph+"/ui/callback"),
-		OAuthPublic(true),
 	)
 	if err != nil {
 		return err
@@ -132,7 +131,7 @@ func (c *OAuthClientStore) InitDefaultClients(ctx context.Context, ph string) er
 	}
 
 	cli, err := NewOAuthClient("enseada-cli", "",
-		OAuthGrantTypes("refresh_token", "password", "client_credentials"),
+		OAuthGrantTypes("refresh_token", "password", "client_credentials", "personal_access_token"),
 		OAuthResponseTypes("code", "id_token", "token id_token", "code id_token", "code token", "code token id_token"),
 		OAuthScopes("*"),
 		OAuthPublic(true),

--- a/internal/auth/oauth_request.go
+++ b/internal/auth/oauth_request.go
@@ -16,12 +16,13 @@ import (
 )
 
 type OAuthRequestWrapper struct {
-	ID      string        `json:"_id,omitempty"`
-	Rev     string        `json:"_rev,omitempty"`
-	Kind    couch.Kind    `json:"kind"`
-	Req     *OAuthRequest `json:"req"`
-	Revoked bool          `json:"revoked,omitempty"`
-	Sig     string        `json:"sig,omitempty"`
+	ID        string        `json:"_id,omitempty"`
+	Rev       string        `json:"_rev,omitempty"`
+	Kind      couch.Kind    `json:"kind"`
+	Req       *OAuthRequest `json:"req"`
+	Revoked   bool          `json:"revoked,omitempty"`
+	Sig       string        `json:"sig,omitempty"`
+	GrantType string        `json:"grant_type,omitempty"`
 }
 
 type OAuthRequest struct {

--- a/internal/auth/oauth_request.go
+++ b/internal/auth/oauth_request.go
@@ -124,6 +124,7 @@ func (r *OAuthRequest) Merge(request fosite.Requester) {
 	r.Client = request.GetClient().(*OAuthClient)
 	r.SetSession(request.GetSession())
 	r.Form = request.GetRequestForm()
+	r.ID = request.GetID()
 }
 
 func (r *OAuthRequest) Sanitize(allowedParameters []string) fosite.Requester {

--- a/internal/auth/oauth_request.go
+++ b/internal/auth/oauth_request.go
@@ -129,5 +129,9 @@ func (r *OAuthRequest) Merge(request fosite.Requester) {
 }
 
 func (r *OAuthRequest) Sanitize(allowedParameters []string) fosite.Requester {
+	// Delete known critical values
+	r.GetRequestForm().Del("password")
+	r.GetRequestForm().Del("client_secret")
+	r.GetRequestForm().Del("token")
 	return r
 }

--- a/internal/auth/oauth_request_store.go
+++ b/internal/auth/oauth_request_store.go
@@ -71,9 +71,10 @@ func (t *OAuthRequestStore) CreateAccessTokenSession(ctx context.Context, signat
 	req := &OAuthRequest{}
 	req.Merge(request)
 	return t.store(ctx, &OAuthRequestWrapper{
-		Kind: couch.KindOAuthAccessToken,
-		Sig:  signature,
-		Req:  req,
+		Kind:      couch.KindOAuthAccessToken,
+		Sig:       signature,
+		Req:       req,
+		GrantType: req.GetRequestForm().Get("grant_type"),
 	})
 }
 

--- a/internal/auth/v1beta1/acl_api.go
+++ b/internal/auth/v1beta1/acl_api.go
@@ -9,6 +9,8 @@ package authv1beta1api
 import (
 	"context"
 
+	"github.com/ory/fosite"
+
 	"github.com/enseadaio/enseada/pkg/log"
 
 	"github.com/enseadaio/enseada/internal/ctxutils"
@@ -35,7 +37,7 @@ func (s *AclAPI) ListRules(ctx context.Context, req *authv1beta1.ListRulesReques
 		return nil, twirp.NewError(twirp.Unauthenticated, "")
 	}
 
-	if !scopes.Has(scope.ACLRuleRead) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.ACLRuleRead) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -66,7 +68,7 @@ func (s *AclAPI) AddRule(ctx context.Context, req *authv1beta1.AddRuleRequest) (
 		return nil, twirp.NewError(twirp.Unauthenticated, "")
 	}
 
-	if !scopes.Has(scope.ACLRuleWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.ACLRuleWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -101,7 +103,7 @@ func (s *AclAPI) DeleteRule(ctx context.Context, req *authv1beta1.DeleteRuleRequ
 		return nil, twirp.NewError(twirp.Unauthenticated, "")
 	}
 
-	if !scopes.Has(scope.ACLRuleDelete) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.ACLRuleDelete) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 

--- a/internal/auth/v1beta1/oauth_clients_api.go
+++ b/internal/auth/v1beta1/oauth_clients_api.go
@@ -41,7 +41,7 @@ func (o *OAuthClientsAPI) ListClients(ctx context.Context, req *authv1beta1.List
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.OAuthClientRead) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.OAuthClientRead) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -97,7 +97,7 @@ func (o *OAuthClientsAPI) GetClient(ctx context.Context, req *authv1beta1.GetCli
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.OAuthClientRead) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.OAuthClientRead) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -136,7 +136,7 @@ func (o *OAuthClientsAPI) CreateClient(ctx context.Context, req *authv1beta1.Cre
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.OAuthClientWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.OAuthClientWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -183,7 +183,7 @@ func (o *OAuthClientsAPI) UpdateClient(ctx context.Context, req *authv1beta1.Upd
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.OAuthClientWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.OAuthClientWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -242,7 +242,7 @@ func (o *OAuthClientsAPI) DeleteClient(ctx context.Context, req *authv1beta1.Del
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.OAuthClientWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.OAuthClientWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 

--- a/internal/maven/file.go
+++ b/internal/maven/file.go
@@ -8,7 +8,7 @@ package maven
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,7 +21,7 @@ import (
 
 const StoragePrefix = couch.MavenDB
 
-type SHA1Checksum [20]byte
+type SHA256Checksum [sha256.Size]byte
 
 type RepoFile struct {
 	Repo         *Repo
@@ -31,7 +31,7 @@ type RepoFile struct {
 	path         string
 	storage      storage.Backend
 	lastModified time.Time
-	checksum     SHA1Checksum
+	checksum     SHA256Checksum
 }
 
 func (f *RepoFile) Content() ([]byte, error) {
@@ -57,17 +57,17 @@ func (f *RepoFile) LastModified() (time.Time, error) {
 	return f.lastModified, nil
 }
 
-func (f *RepoFile) Checksum() (SHA1Checksum, error) {
-	if f.checksum != [20]byte{} {
+func (f *RepoFile) Checksum() (SHA256Checksum, error) {
+	if f.checksum != [sha256.Size]byte{} {
 		return f.checksum, nil
 	}
 
 	c, err := f.Content()
 	if err != nil {
-		return SHA1Checksum{}, err
+		return SHA256Checksum{}, err
 	}
 
-	cs := sha1.Sum(c)
+	cs := sha256.Sum256(c)
 	f.checksum = cs
 	return cs, nil
 }

--- a/internal/maven/v1beta1/api.go
+++ b/internal/maven/v1beta1/api.go
@@ -9,6 +9,8 @@ package mavenv1beta1api
 import (
 	"context"
 
+	"github.com/ory/fosite"
+
 	"github.com/enseadaio/enseada/internal/ctxutils"
 
 	"github.com/casbin/casbin/v2"
@@ -32,7 +34,7 @@ func (s Service) ListRepos(ctx context.Context, req *mavenv1beta1.ListReposReque
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.MavenRepoRead) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.MavenRepoRead) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -91,7 +93,7 @@ func (s Service) GetRepo(ctx context.Context, req *mavenv1beta1.GetRepoRequest) 
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.MavenRepoRead) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.MavenRepoRead) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -134,7 +136,7 @@ func (s Service) CreateRepo(ctx context.Context, req *mavenv1beta1.CreateRepoReq
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.MavenRepoWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.MavenRepoWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 
@@ -180,7 +182,7 @@ func (s Service) DeleteRepo(ctx context.Context, req *mavenv1beta1.DeleteRepoReq
 	}
 
 	scopes, _ := ctxutils.Scopes(ctx)
-	if !scopes.Has(scope.MavenRepoWrite) {
+	if !fosite.WildcardScopeStrategy(scopes, scope.MavenRepoWrite) {
 		return nil, twirp.NewError(twirp.PermissionDenied, "insufficient scopes")
 	}
 

--- a/pkg/auth/http.go
+++ b/pkg/auth/http.go
@@ -35,6 +35,7 @@ func mountRoutes(e *echo.Echo, s *auth.Store, op fosite.OAuth2Provider, enf *cas
 	g.GET("/authorize", authorizationPage())
 	g.POST("/authorize", authorize(op, s))
 	g.POST("/token", token(op, s))
+	g.POST("/revoke", revoke(op))
 	g.POST("/token/introspect", introspect(op))
 
 	acl := authv1beta1api.NewAclAPI(s.Logger, enf)
@@ -174,6 +175,18 @@ func token(oauth fosite.OAuth2Provider, store *auth.Store) echo.HandlerFunc {
 		}
 
 		oauth.WriteAccessResponse(resw, ar, res)
+		return nil
+	}
+}
+
+func revoke(oauth fosite.OAuth2Provider) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		req := c.Request()
+		resw := c.Response().Writer
+		ctx := req.Context()
+
+		err := oauth.NewRevocationRequest(ctx, req)
+		oauth.WriteRevocationResponse(resw, err)
 		return nil
 	}
 }

--- a/pkg/auth/module.go
+++ b/pkg/auth/module.go
@@ -89,6 +89,7 @@ func NewModule(ctx context.Context, logger log.Logger, data *kivik.Client, e *ec
 		compose.OAuth2ClientCredentialsGrantFactory,
 		compose.OAuth2RefreshTokenGrantFactory,
 		compose.OAuth2ResourceOwnerPasswordCredentialsFactory,
+		compose.OAuth2TokenRevocationFactory,
 
 		compose.OpenIDConnectExplicitFactory,
 		compose.OpenIDConnectImplicitFactory,

--- a/pkg/auth/module.go
+++ b/pkg/auth/module.go
@@ -31,18 +31,19 @@ import (
 )
 
 type Module struct {
-	logger   log.Logger
-	e        *echo.Echo
-	data     *kivik.Client
-	ph       string
-	rootpwd  string
-	Store    *auth.Store
-	Enforcer *casbin.Enforcer
-	Watcher  *CasbinWatcher
-	Provider fosite.OAuth2Provider
+	logger              log.Logger
+	e                   *echo.Echo
+	data                *kivik.Client
+	ph                  string
+	rootpwd             string
+	Store               *auth.Store
+	Enforcer            *casbin.Enforcer
+	Watcher             *CasbinWatcher
+	Provider            fosite.OAuth2Provider
+	DefaultClientSecret string
 }
 
-func NewModule(ctx context.Context, logger log.Logger, data *kivik.Client, e *echo.Echo, errh errare.Handler, r *metric.Registry, skb []byte, ph string, rootpwd string) (*Module, error) {
+func NewModule(ctx context.Context, logger log.Logger, data *kivik.Client, e *echo.Echo, errh errare.Handler, r *metric.Registry, skb []byte, ph string, rootpwd string, defaultClientSecret string) (*Module, error) {
 	if err := couch.Transact(ctx, logger, data, migrateAclDb, couch.AclDB); err != nil {
 		return nil, err
 	}
@@ -97,6 +98,8 @@ func NewModule(ctx context.Context, logger log.Logger, data *kivik.Client, e *ec
 		compose.OAuth2TokenIntrospectionFactory,
 
 		compose.OAuth2PKCEFactory,
+
+		auth.PersonalAccessTokenFactory,
 	)
 
 	m, err := auth.InitMetrics(ctx, r, s)
@@ -109,15 +112,16 @@ func NewModule(ctx context.Context, logger log.Logger, data *kivik.Client, e *ec
 	}
 
 	return &Module{
-		logger:   logger,
-		e:        e,
-		data:     data,
-		ph:       ph,
-		rootpwd:  rootpwd,
-		Store:    s,
-		Enforcer: enf,
-		Watcher:  w,
-		Provider: op,
+		logger:              logger,
+		e:                   e,
+		data:                data,
+		ph:                  ph,
+		rootpwd:             rootpwd,
+		Store:               s,
+		Enforcer:            enf,
+		Watcher:             w,
+		Provider:            op,
+		DefaultClientSecret: defaultClientSecret,
 	}, nil
 }
 
@@ -142,7 +146,7 @@ func (m *Module) EventHandlers() app.EventHandlersMap {
 }
 
 func (m *Module) beforeAppStart(ctx context.Context, event app.LifecycleEvent) {
-	if err := m.Store.InitDefaultClients(ctx, m.ph); err != nil {
+	if err := m.Store.InitDefaultClients(ctx, m.ph, m.DefaultClientSecret); err != nil {
 		panic(err)
 	}
 	m.logger.Debug("default OAuth clients initialized")

--- a/pkg/http/ui.go
+++ b/pkg/http/ui.go
@@ -85,6 +85,7 @@ func callback(oc *goauth.Config) echo.HandlerFunc {
 			return err
 		}
 
+		req.SetBasicAuth(oc.ClientID, oc.ClientSecret)
 		req.Header.Set("content-type", "application/x-www-form-urlencoded")
 		req.Header.Add("Accept-Encoding", "identity")
 		res, err := cl.Do(req)

--- a/pkg/maven/http.go
+++ b/pkg/maven/http.go
@@ -55,7 +55,7 @@ func getMaven(mvn *maven.Maven, enf *casbin.Enforcer) echo.HandlerFunc {
 		}
 
 		scopes, _ := ctxutils.Scopes(ctx)
-		if !scopes.Has(scope.MavenFileRead) {
+		if !fosite.WildcardScopeStrategy(scopes, scope.MavenFileRead) {
 			return c.JSON(http.StatusForbidden, utils.HTTPError(http.StatusForbidden, "insufficient scopes"))
 		}
 
@@ -135,7 +135,7 @@ func storeMaven(mvn *maven.Maven, enf *casbin.Enforcer) echo.HandlerFunc {
 		}
 
 		scopes, _ := ctxutils.Scopes(ctx)
-		if !scopes.Has(scope.MavenFileWrite) {
+		if !fosite.WildcardScopeStrategy(scopes, scope.MavenFileWrite) {
 			return c.JSON(http.StatusForbidden, utils.HTTPError(http.StatusForbidden, "insufficient scopes"))
 		}
 


### PR DESCRIPTION
Implemented a custom OAuth grant type to generate personal access tokens, special long-lived access tokens (100 years expiration) that can be used in scenarios where generating or refreshing tokens is impractical (like authenticating Maven). 

Also implemented the OAuth revocation endpoint to revoke generated tokens (of every kind).