### PR TITLE
couch db error: add docs

### DIFF
--- a/couchdb/src/error.rs
+++ b/couchdb/src/error.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 use std::fmt::Display;
 
 use reqwest::StatusCode;
@@ -5,6 +7,7 @@ use serde::export::Formatter;
 
 use crate::migrator;
 
+/// HTTP status code with an attached message.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error {
     message: String,
@@ -12,6 +15,7 @@ pub struct Error {
 }
 
 impl Error {
+    /// Create an error with the HTTP 404 Not Found error and the given `message`.
     pub fn not_found(message: String) -> Self {
         Error {
             message,
@@ -19,6 +23,7 @@ impl Error {
         }
     }
 
+    /// Get error HTTP status code
     pub fn status(&self) -> StatusCode {
         self.status
     }

--- a/couchdb/src/lib.rs
+++ b/couchdb/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use std::sync::Arc;
 
 use url::Url;
@@ -11,6 +13,7 @@ pub mod changes;
 pub mod client;
 pub mod db;
 pub mod design_document;
+/// couch db error
 pub mod error;
 pub mod index;
 pub mod migrator;


### PR DESCRIPTION
Final goal should be to put the `#![warn(missing_docs)]` macro in the `lib.rs` file.